### PR TITLE
[fix] Possible overflow when allocating contiguous physical memory in…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ fn find_contiguous(
     size: usize,
     align_log2: usize,
 ) -> Option<usize> {
-    if capacity < (1 << align_log2) || ba.is_empty() {
+    if align_log2 >= 64 || capacity < (1 << align_log2) || ba.is_empty() {
         return None;
     }
 
@@ -356,7 +356,7 @@ fn check_contiguous(
     size: usize,
     align_log2: usize,
 ) -> bool {
-    if capacity < (1 << align_log2) || ba.is_empty() {
+    if align_log2 >= 64 || capacity < (1 << align_log2) || ba.is_empty() {
         return false;
     }
 


### PR DESCRIPTION
… bitmap-allocator

![Image](https://github.com/user-attachments/assets/f6ce4f74-c386-4e81-977b-46b7064a2f31)

When `align_log2 >= 64` , the values of `1 << align_log2` and `base` will always be equal to 0, causing the while loop not to terminate and the program to panic. ![Image](https://github.com/user-attachments/assets/8f7cee30-9a90-4b60-a00c-1ce2a6ec78d6)

![Image](https://github.com/user-attachments/assets/cd3feb13-d099-44f2-8b4c-597d4d04a747)