### PR TITLE
docs: improve documentation formatting, punctuation, and spelling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,20 +38,20 @@ pub trait BitAlloc: Default {
     /// Returns true if successful, false if the bits in the range are already free.
     fn dealloc_contiguous(&mut self, base: usize, size: usize) -> bool;
 
-    /// Mark bits in the range as unallocated (available)
+    /// Mark bits in the range as unallocated (available).
     fn insert(&mut self, range: Range<usize>);
 
-    /// Reverse of insert
+    /// Reverse of insert.
     fn remove(&mut self, range: Range<usize>);
 
-    /// Whether there are free bits remaining
+    /// Whether there are free bits remaining.
     #[deprecated = "use `!self.is_empty()` instead"]
     fn any(&self) -> bool;
 
     /// Returns true if no bits is available.
     fn is_empty(&self) -> bool;
 
-    /// Whether a specific bit is free
+    /// Whether a specific bit is free.
     fn test(&self, key: usize) -> bool;
 }
 
@@ -92,7 +92,7 @@ pub type BitAlloc256M = BitAllocCascade16<BitAlloc16M>;
 /// Implement the bit allocator by segment tree algorithm.
 #[derive(Default)]
 pub struct BitAllocCascade16<T: BitAlloc> {
-    /// for each bit, 1 indicates available, 0 indicates inavailable
+    /// For each bit, 1 indicates available, 0 indicates unavailable.
     bitset: u16,
     sub: [T; 16],
 }
@@ -143,7 +143,7 @@ impl<T: BitAlloc> BitAlloc for BitAllocCascade16<T> {
         let mut success = true;
         let Range { start, end } = base..base + size;
 
-        // Check if the range is valid.
+        // Prevent out-of-bounds access by ensuring the deallocation range fits within capacity.
         if end > Self::CAP {
             return false;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub trait BitAlloc: Default {
     #[deprecated = "use `!self.is_empty()` instead"]
     fn any(&self) -> bool;
 
-    /// Returns true if no bits is available.
+    /// Returns true if no bits are available.
     fn is_empty(&self) -> bool;
 
     /// Whether a specific bit is free.
@@ -92,7 +92,7 @@ pub type BitAlloc256M = BitAllocCascade16<BitAlloc16M>;
 /// Implement the bit allocator by segment tree algorithm.
 #[derive(Default)]
 pub struct BitAllocCascade16<T: BitAlloc> {
-    /// For each bit, 1 indicates available, 0 indicates unavailable.
+    /// For each sub-allocator, the corresponding bit is 1 when it has free bits available.
     bitset: u16,
     sub: [T; 16],
 }


### PR DESCRIPTION
  This PR improves the documentation comments in src/lib.rs to better align with Rust documentation standards (RFC 1574) and the project's coding guidelines.


  Specific changes include:
   - Punctuation & Capitalization: Added missing periods at the end of single-line doc comments for methods like insert, remove, any, and test to ensure they form proper summary sentences. Capitalized the first letter of the bitset field documentation.
   - Spelling: Corrected a typo in the bitset doc comment (inavailable -> unavailable).
   - Comment Clarity: Improved an inline comment in dealloc_contiguous. Changed the descriptive // Check if the range is valid. to an intent-revealing comment // Prevent out-of-bounds access by ensuring the deallocation range fits within capacity., explaining the why rather than just the what.


  Related Guidelines:
   - comment-punctuation: Ensure all full-sentence comments end with a period.
   - explain-why: Replace comments that describe what the code does with comments explaining the intent or reasoning.


  Testing:
   - Ran cargo doc --no-deps to ensure documentation renders correctly.
   - Ran cargo test to ensure no code logic was affected.