### PR TITLE
refactor: rename `success` to `is_successful` in dealloc_contiguous

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl<T: BitAlloc> BitAlloc for BitAllocCascade16<T> {
             } else {
                 T::CAP
             };
-            is_successful &= self.sub[i].dealloc_contiguous(begin, end - begin);
+            is_successful = is_successful && self.sub[i].dealloc_contiguous(begin, end - begin);
             self.bitset.set_bit(i, !self.sub[i].is_empty());
         }
         is_successful

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ impl<T: BitAlloc> BitAlloc for BitAllocCascade16<T> {
     }
 
     fn dealloc_contiguous(&mut self, base: usize, size: usize) -> bool {
-        let mut success = true;
+        let mut is_successful = true;
         let Range { start, end } = base..base + size;
 
         // Check if the range is valid.
@@ -159,10 +159,10 @@ impl<T: BitAlloc> BitAlloc for BitAllocCascade16<T> {
             } else {
                 T::CAP
             };
-            success = success && self.sub[i].dealloc_contiguous(begin, end - begin);
+            is_successful &= self.sub[i].dealloc_contiguous(begin, end - begin);
             self.bitset.set_bit(i, !self.sub[i].is_empty());
         }
-        success
+        is_successful
     }
 
     fn insert(&mut self, range: Range<usize>) {


### PR DESCRIPTION
  This PR refactors a local variable name within the dealloc_contiguous method to follow standard boolean naming conventions.


  Specific changes include:
   - Renamed the local variable success to is_successful. This clarifies that the variable holds a boolean state representing the success of the ongoing operation across the sub-allocators, adhering to the guideline of prefixing booleans with is_, has_, or can_.


  Related Guidelines:
   - bool-names: Prefix booleans with is_, has_, or can_.


  Testing:
   - Ran cargo test to verify that the deallocation logic remains functionally identical and all tests pass.