### PR TITLE
feat: add experimental alloc-backed large allocators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,9 @@ repository = "https://github.com/rcore-os/bitmap-allocator"
 keywords = ["bitmap", "allocator", "memory"]
 categories = ["memory-management", "no-std"]
 
+[features]
+default = []
+alloc = []
+
 [dependencies]
 bit_field = "0.10"

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ ba.dealloc(0);
 ba.dealloc(1);
 ba.dealloc(8);
 ```
+
+## Experimental alloc-backed variants
+
+When the `alloc` feature is enabled, the crate also exposes experimental
+heap-backed variants such as `HeapBitAlloc16M` and `HeapBitAlloc256M` for
+large-capacity use cases.

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,0 +1,326 @@
+use alloc::boxed::Box;
+use bit_field::BitField;
+use core::{array::from_fn, ops::Range};
+
+use crate::{BitAlloc, BitAlloc16};
+
+/// Runtime allocator API for heap-backed bitmap allocators.
+///
+/// Unlike [`BitAlloc`], this trait does not require a `const DEFAULT`, so
+/// implementations may use heap storage during construction.
+pub trait BitAllocRuntime: Default {
+    /// The bitmap has a total of CAP bits, numbered from 0 to CAP-1 inclusively.
+    const CAP: usize;
+
+    /// Allocate a free bit.
+    fn alloc(&mut self) -> Option<usize>;
+
+    /// Allocate a free block with a given size, and return the first bit position.
+    ///
+    /// If `base` is not `None`, the allocator will try to allocate the block at
+    /// the given base.
+    fn alloc_contiguous(
+        &mut self,
+        base: Option<usize>,
+        size: usize,
+        align_log2: usize,
+    ) -> Option<usize>;
+
+    /// Find an index not less than a given key, where the bit is free.
+    fn next(&self, key: usize) -> Option<usize>;
+
+    /// Free an allocated bit.
+    ///
+    /// Returns true if successful, false if the bit is already free.
+    fn dealloc(&mut self, key: usize) -> bool;
+
+    /// Free a contiguous block of bits.
+    ///
+    /// Returns true if successful, false if the bits in the range are already free.
+    fn dealloc_contiguous(&mut self, base: usize, size: usize) -> bool;
+
+    /// Mark bits in the range as unallocated (available).
+    fn insert(&mut self, range: Range<usize>);
+
+    /// Reverse of insert.
+    fn remove(&mut self, range: Range<usize>);
+
+    /// Returns true if no bits are available.
+    fn is_empty(&self) -> bool;
+
+    /// Whether a specific bit is free.
+    fn test(&self, key: usize) -> bool;
+}
+
+#[doc(hidden)]
+#[derive(Default)]
+pub struct HeapBitAlloc16Leaf(BitAlloc16);
+
+impl BitAllocRuntime for HeapBitAlloc16Leaf {
+    const CAP: usize = <BitAlloc16 as BitAlloc>::CAP;
+
+    fn alloc(&mut self) -> Option<usize> {
+        self.0.alloc()
+    }
+
+    fn alloc_contiguous(
+        &mut self,
+        base: Option<usize>,
+        size: usize,
+        align_log2: usize,
+    ) -> Option<usize> {
+        self.0.alloc_contiguous(base, size, align_log2)
+    }
+
+    fn next(&self, key: usize) -> Option<usize> {
+        self.0.next(key)
+    }
+
+    fn dealloc(&mut self, key: usize) -> bool {
+        self.0.dealloc(key)
+    }
+
+    fn dealloc_contiguous(&mut self, base: usize, size: usize) -> bool {
+        self.0.dealloc_contiguous(base, size)
+    }
+
+    fn insert(&mut self, range: Range<usize>) {
+        self.0.insert(range);
+    }
+
+    fn remove(&mut self, range: Range<usize>) {
+        self.0.remove(range);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn test(&self, key: usize) -> bool {
+        self.0.test(key)
+    }
+}
+
+/// Heap-backed variant of the 16-way cascade allocator.
+///
+/// This keeps the root value small and moves the recursive storage into heap
+/// allocations, which makes large-capacity aliases practical to construct.
+pub struct HeapBitAllocCascade16<T: BitAllocRuntime> {
+    bitset: u16,
+    sub: Box<[T; 16]>,
+}
+
+impl<T: BitAllocRuntime> Default for HeapBitAllocCascade16<T> {
+    fn default() -> Self {
+        Self {
+            bitset: 0,
+            sub: Box::new(from_fn(|_| T::default())),
+        }
+    }
+}
+
+impl<T: BitAllocRuntime> BitAllocRuntime for HeapBitAllocCascade16<T> {
+    const CAP: usize = T::CAP * 16;
+
+    fn alloc(&mut self) -> Option<usize> {
+        if !self.is_empty() {
+            let i = self.bitset.trailing_zeros() as usize;
+            let res = self.sub[i].alloc().unwrap() + i * T::CAP;
+            self.bitset.set_bit(i, !self.sub[i].is_empty());
+            Some(res)
+        } else {
+            None
+        }
+    }
+
+    fn alloc_contiguous(
+        &mut self,
+        base: Option<usize>,
+        size: usize,
+        align_log2: usize,
+    ) -> Option<usize> {
+        match base {
+            Some(base) => {
+                check_contiguous_runtime(self, base, Self::CAP, size, align_log2).then(|| {
+                    self.remove(base..base + size);
+                    base
+                })
+            }
+            None => find_contiguous_runtime(self, Self::CAP, size, align_log2).inspect(|&base| {
+                self.remove(base..base + size);
+            }),
+        }
+    }
+
+    fn dealloc(&mut self, key: usize) -> bool {
+        let i = key / T::CAP;
+        self.bitset.set_bit(i, true);
+        self.sub[i].dealloc(key % T::CAP)
+    }
+
+    fn dealloc_contiguous(&mut self, base: usize, size: usize) -> bool {
+        let mut success = true;
+        let Range { start, end } = base..base + size;
+
+        if end > Self::CAP {
+            return false;
+        }
+
+        for i in start / T::CAP..=(end - 1) / T::CAP {
+            let begin = if start / T::CAP == i {
+                start % T::CAP
+            } else {
+                0
+            };
+            let end = if end / T::CAP == i {
+                end % T::CAP
+            } else {
+                T::CAP
+            };
+            success = success && self.sub[i].dealloc_contiguous(begin, end - begin);
+            self.bitset.set_bit(i, !self.sub[i].is_empty());
+        }
+        success
+    }
+
+    fn insert(&mut self, range: Range<usize>) {
+        self.for_range(range, |sub, range| sub.insert(range));
+    }
+
+    fn remove(&mut self, range: Range<usize>) {
+        self.for_range(range, |sub, range| sub.remove(range));
+    }
+
+    fn is_empty(&self) -> bool {
+        self.bitset == 0
+    }
+
+    fn test(&self, key: usize) -> bool {
+        self.sub[key / T::CAP].test(key % T::CAP)
+    }
+
+    fn next(&self, key: usize) -> Option<usize> {
+        let idx = key / T::CAP;
+        (idx..16).find_map(|i| {
+            if self.bitset.get_bit(i) {
+                let key = if i == idx { key - T::CAP * idx } else { 0 };
+                self.sub[i].next(key).map(|x| x + T::CAP * i)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+impl<T: BitAllocRuntime> HeapBitAllocCascade16<T> {
+    fn for_range(&mut self, range: Range<usize>, f: impl Fn(&mut T, Range<usize>)) {
+        let Range { start, end } = range;
+        assert!(start <= end);
+        assert!(end <= Self::CAP);
+        for i in start / T::CAP..=(end - 1) / T::CAP {
+            let begin = if start / T::CAP == i {
+                start % T::CAP
+            } else {
+                0
+            };
+            let end = if end / T::CAP == i {
+                end % T::CAP
+            } else {
+                T::CAP
+            };
+            f(&mut self.sub[i], begin..end);
+            self.bitset.set_bit(i, !self.sub[i].is_empty());
+        }
+    }
+}
+
+fn find_contiguous_runtime(
+    ba: &impl BitAllocRuntime,
+    capacity: usize,
+    size: usize,
+    align_log2: usize,
+) -> Option<usize> {
+    if align_log2 >= 64 || capacity < (1 << align_log2) || ba.is_empty() {
+        return None;
+    }
+
+    let mut base = 0;
+    if let Some(start) = ba.next(base) {
+        base = align_up_log2(start, align_log2);
+    } else {
+        return None;
+    }
+
+    let mut offset = base;
+
+    while offset < capacity {
+        if let Some(next) = ba.next(offset) {
+            if next != offset {
+                assert!(next > offset);
+                base = (((next - 1) >> align_log2) + 1) << align_log2;
+                offset = base;
+                continue;
+            }
+        } else {
+            return None;
+        }
+        offset += 1;
+        if offset - base == size {
+            return Some(base);
+        }
+    }
+    None
+}
+
+fn check_contiguous_runtime(
+    ba: &impl BitAllocRuntime,
+    base: usize,
+    capacity: usize,
+    size: usize,
+    align_log2: usize,
+) -> bool {
+    if align_log2 >= 64 || capacity < (1 << align_log2) || ba.is_empty() {
+        return false;
+    }
+
+    if !is_aligned_log2(base, align_log2) {
+        return false;
+    }
+
+    let mut offset = base;
+    while offset < capacity {
+        if let Some(next) = ba.next(offset) {
+            if next != offset {
+                return false;
+            }
+            offset += 1;
+            if offset - base == size {
+                return true;
+            }
+        } else {
+            return false;
+        }
+    }
+    false
+}
+
+fn align_up_log2(base: usize, align_log2: usize) -> usize {
+    (base + ((1 << align_log2) - 1)) & !((1 << align_log2) - 1)
+}
+
+fn is_aligned_log2(base: usize, align_log2: usize) -> bool {
+    (base & ((1 << align_log2) - 1)) == 0
+}
+
+/// Heap-backed bitmap of 256 bits.
+pub type HeapBitAlloc256 = HeapBitAllocCascade16<HeapBitAlloc16Leaf>;
+/// Heap-backed bitmap of 4K bits.
+pub type HeapBitAlloc4K = HeapBitAllocCascade16<HeapBitAlloc256>;
+/// Heap-backed bitmap of 64K bits.
+pub type HeapBitAlloc64K = HeapBitAllocCascade16<HeapBitAlloc4K>;
+/// Heap-backed bitmap of 1M bits.
+pub type HeapBitAlloc1M = HeapBitAllocCascade16<HeapBitAlloc64K>;
+/// Heap-backed bitmap of 16M bits.
+pub type HeapBitAlloc16M = HeapBitAllocCascade16<HeapBitAlloc1M>;
+/// Heap-backed bitmap of 256M bits.
+pub type HeapBitAlloc256M = HeapBitAllocCascade16<HeapBitAlloc16M>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,20 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 use bit_field::BitField;
 use core::ops::Range;
+
+#[cfg(feature = "alloc")]
+pub mod heap;
+
+#[cfg(feature = "alloc")]
+pub use heap::{
+    BitAllocRuntime, HeapBitAlloc16M, HeapBitAlloc1M, HeapBitAlloc256, HeapBitAlloc256M,
+    HeapBitAlloc4K, HeapBitAlloc64K,
+};
 
 /// Allocator of a bitmap, able to allocate / free bits.
 pub trait BitAlloc: Default {
@@ -425,17 +437,17 @@ mod tests {
         assert!(!ba.dealloc(0));
 
         assert_eq!(ba.alloc(), Some(0));
-        assert_eq!(ba.test(0), false);
+        assert!(!ba.test(0));
         assert_eq!(ba.alloc_contiguous(None, 2, 0), Some(1));
-        assert_eq!(ba.test(1), false);
-        assert_eq!(ba.test(2), false);
+        assert!(!ba.test(1));
+        assert!(!ba.test(2));
 
         // Test alloc alignment.
         assert_eq!(ba.alloc_contiguous(None, 2, 1), Some(4));
         // Bit 3 is free due to alignment.
-        assert_eq!(ba.test(3), true);
-        assert_eq!(ba.test(4), false);
-        assert_eq!(ba.test(5), false);
+        assert!(ba.test(3));
+        assert!(!ba.test(4));
+        assert!(!ba.test(5));
         assert_eq!(ba.next(5), Some(6));
 
         // Test alloc alignment.

--- a/tests/heap_alloc.rs
+++ b/tests/heap_alloc.rs
@@ -1,0 +1,33 @@
+#![cfg(feature = "alloc")]
+
+use core::mem::size_of;
+
+use bitmap_allocator::heap::{BitAllocRuntime, HeapBitAlloc16M, HeapBitAlloc256M};
+
+fn smoke_runtime_alloc<T: BitAllocRuntime + Default>() {
+    let mut ba = T::default();
+    ba.insert(8..24);
+    assert!(!ba.is_empty());
+    assert_eq!(ba.alloc(), Some(8));
+    assert_eq!(ba.alloc(), Some(9));
+    assert!(ba.test(10));
+    assert!(ba.dealloc(8));
+    assert_eq!(ba.alloc_contiguous(Some(16), 4, 2), Some(16));
+    assert_eq!(ba.next(16), Some(20));
+}
+
+#[test]
+fn heap_bitalloc_roots_stay_small() {
+    assert!(size_of::<HeapBitAlloc16M>() < 64);
+    assert!(size_of::<HeapBitAlloc256M>() < 64);
+}
+
+#[test]
+fn heap_bitalloc16m_supports_basic_operations() {
+    smoke_runtime_alloc::<HeapBitAlloc16M>();
+}
+
+#[test]
+fn heap_bitalloc256m_supports_basic_operations() {
+    smoke_runtime_alloc::<HeapBitAlloc256M>();
+}


### PR DESCRIPTION
## Summary
- add an optional `alloc` feature
- introduce a `BitAllocRuntime` trait for heap-backed implementations that do not require `const DEFAULT`
- add `HeapBitAllocCascade16<T>` and export `HeapBitAlloc1M`, `HeapBitAlloc16M`, and `HeapBitAlloc256M`
- add tests showing that the heap-backed roots stay small and support the same basic allocation operations as the existing value-based allocators

## Why
The current large-capacity aliases are valid types, but they are impractical to construct as ordinary local values because the recursive representation grows too large for a typical thread stack.

This PR adds an experimental `alloc`-backed construction path for large allocators without changing the existing `BitAlloc` API or the current by-value aliases.

## Testing
- `cargo test --features alloc`
- `cargo clippy --features alloc --tests`

