### PR TITLE
feat: gate large value-type aliases behind a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,9 @@ repository = "https://github.com/rcore-os/bitmap-allocator"
 keywords = ["bitmap", "allocator", "memory"]
 categories = ["memory-management", "no-std"]
 
+[features]
+default = []
+large-value-types = []
+
 [dependencies]
 bit_field = "0.10"

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ ba.dealloc(0);
 ba.dealloc(1);
 ba.dealloc(8);
 ```
+
+## Large allocator note
+
+The larger by-value aliases are hidden behind the `large-value-types` feature:
+`BitAlloc16M` and `BitAlloc256M`.
+
+Even with that feature enabled, those aliases are still plain by-value Rust
+types. Starting from `BitAlloc16M`, they become large enough that constructing
+them as ordinary local variables may overflow a typical thread stack.
+
+For large-capacity allocators, prefer caller-managed non-stack storage instead
+of writing `let mut ba = BitAlloc16M::default();` on a small stack.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,10 +84,25 @@ pub type BitAlloc4K = BitAllocCascade16<BitAlloc256>;
 pub type BitAlloc64K = BitAllocCascade16<BitAlloc4K>;
 /// A bitmap of 1M bits
 pub type BitAlloc1M = BitAllocCascade16<BitAlloc64K>;
-/// A bitmap of 16M bits
-pub type BitAlloc16M = BitAllocCascade16<BitAlloc1M>;
-/// A bitmap of 256M bits
-pub type BitAlloc256M = BitAllocCascade16<BitAlloc16M>;
+#[cfg(feature = "large-value-types")]
+type BitAlloc16MValue = BitAllocCascade16<BitAlloc1M>;
+#[cfg(feature = "large-value-types")]
+type BitAlloc256MValue = BitAllocCascade16<BitAlloc16MValue>;
+/// A bitmap of 16M bits.
+///
+/// This is still a plain by-value type. Constructing it as a local variable on
+/// a small thread stack may overflow the stack.
+///
+/// This alias is intentionally gated behind the `large-value-types` feature.
+#[cfg(feature = "large-value-types")]
+pub type BitAlloc16M = BitAlloc16MValue;
+/// A bitmap of 256M bits.
+///
+/// This is still a plain by-value type. Prefer non-stack storage for this type.
+///
+/// This alias is intentionally gated behind the `large-value-types` feature.
+#[cfg(feature = "large-value-types")]
+pub type BitAlloc256M = BitAlloc256MValue;
 
 /// Implement the bit allocator by segment tree algorithm.
 #[derive(Default)]
@@ -393,6 +408,8 @@ fn is_aligned_log2(base: usize, align_log2: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "large-value-types")]
+    use core::mem::size_of;
 
     #[test]
     fn bitalloc16() {
@@ -425,17 +442,17 @@ mod tests {
         assert!(!ba.dealloc(0));
 
         assert_eq!(ba.alloc(), Some(0));
-        assert_eq!(ba.test(0), false);
+        assert!(!ba.test(0));
         assert_eq!(ba.alloc_contiguous(None, 2, 0), Some(1));
-        assert_eq!(ba.test(1), false);
-        assert_eq!(ba.test(2), false);
+        assert!(!ba.test(1));
+        assert!(!ba.test(2));
 
         // Test alloc alignment.
         assert_eq!(ba.alloc_contiguous(None, 2, 1), Some(4));
         // Bit 3 is free due to alignment.
-        assert_eq!(ba.test(3), true);
-        assert_eq!(ba.test(4), false);
-        assert_eq!(ba.test(5), false);
+        assert!(ba.test(3));
+        assert!(!ba.test(4));
+        assert!(!ba.test(5));
         assert_eq!(ba.next(5), Some(6));
 
         // Test alloc alignment.
@@ -534,5 +551,15 @@ mod tests {
         for i in 4096 - 48..4096 - 16 {
             assert!(ba.dealloc(i));
         }
+    }
+
+    #[cfg(feature = "large-value-types")]
+    #[test]
+    fn large_allocator_values_are_large_stack_objects() {
+        assert!(size_of::<BitAlloc1M>() > 128 * 1024);
+        assert!(size_of::<BitAlloc16M>() > 2 * 1024 * 1024);
+        assert!(size_of::<BitAlloc256M>() > 32 * 1024 * 1024);
+        assert!(size_of::<BitAlloc16M>() > size_of::<BitAlloc1M>());
+        assert!(size_of::<BitAlloc256M>() > size_of::<BitAlloc16M>());
     }
 }


### PR DESCRIPTION
## Summary
- add a `large-value-types` feature
- hide `BitAlloc16M` and `BitAlloc256M` behind that explicit opt-in
- update the documentation to point large-capacity users toward the experimental `alloc`-backed variants or non-stack storage
- gate the size-based large-alias test behind the same feature

## Why
`BitAlloc16M` and `BitAlloc256M` are still legitimate aliases, but they are unusually large by-value objects and are easy to misuse as ordinary local variables.

Making those aliases explicit opt-in reduces accidental stack-overflow footguns while still preserving access for callers that intentionally want the current value-based representation.

## Testing
- `cargo test --features 'large-value-types'`
- `cargo clippy --features 'large-value-types' --tests`
